### PR TITLE
Fix failing build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		</repository>
 		<repository>
 			<id>github-public</id>
-			<url>https://public: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@maven.pkg.github.com/kvalitetsit/*</url>
+			<url>https://public:&#103;hp_KMUGxuItDJgOKNjadg54AOQwl4CSLY4dK1ms@maven.pkg.github.com/kvalitetsit/*</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,7 @@
 		</repository>
 		<repository>
 			<id>github-public</id>
-			<url>https://public:&#103;hp_Y6nRFazi9yNo0IMpxwTFIagW352c1539nyfn@maven.pkg.github.com/kvalitetsit/*</url>
-		</repository>
-		<repository>
-			<id>github-public1</id>
-			<url>https://public:&#103;hp_Y6nRFazi9yNo0IMpxwTFIagW352c1539nyfn@maven.pkg.github.com/kvalitetsit/*</url>
+			<url>https://public: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@maven.pkg.github.com/kvalitetsit/*</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
RIM-1244: accesstoken var slettet, udløbet eller på anden måde ikke længere tilgængelig/gyldig